### PR TITLE
Fix `pymc3.ode.DifferentialEquation` for when rhs function returns theano tensor with ndim==1

### DIFF
--- a/pymc3/ode/utils.py
+++ b/pymc3/ode/utils.py
@@ -103,7 +103,7 @@ def augment_system(ode_func, n_states, n_theta):
 
     # Get symbolic representation of the ODEs by passing tensors for y, t and theta
     yhat = ode_func(t_y, t_t, t_p[n_states:])
-    if not isinstance(yhat, tt.TensorVariable):
+    if not (isinstance(yhat, tt.TensorVariable) and yhat.ndim==1):
     # Stack the results of the ode_func into a single tensor variable
         if not isinstance(yhat, (list, tuple)):
             yhat = (yhat,)

--- a/pymc3/ode/utils.py
+++ b/pymc3/ode/utils.py
@@ -103,10 +103,11 @@ def augment_system(ode_func, n_states, n_theta):
 
     # Get symbolic representation of the ODEs by passing tensors for y, t and theta
     yhat = ode_func(t_y, t_t, t_p[n_states:])
+    if not isinstance(yhat, tt.TensorVariable):
     # Stack the results of the ode_func into a single tensor variable
-    if not isinstance(yhat, (list, tuple)):
-        yhat = (yhat,)
-    t_yhat = tt.stack(yhat, axis=0)
+        if not isinstance(yhat, (list, tuple)):
+            yhat = (yhat,)
+        t_yhat = tt.stack(yhat, axis=0)
 
     # Now compute gradients
     J = tt.jacobian(t_yhat, t_y)


### PR DESCRIPTION
Added if-condition inside `augment_system` in `pymc3/ode/utils.py`. This avoids the following error for when the rhs function passed to pymc3.ode.DifferentialEquation is a 1-dimensional theano tensor.

```AssertionError: theano.tensor.jacobian expects a 1 dimensional variable as `expression`. If not use flatten to make it a vector```